### PR TITLE
Added Right Side OP Bump Auto

### DIFF
--- a/src/main/deploy/pathplanner/paths/RBSH_RTSR.path
+++ b/src/main/deploy/pathplanner/paths/RBSH_RTSR.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 2.75,
+        "y": 2.5
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 2.75,
+        "y": 1.0
+      },
+      "isLocked": false,
+      "linkedName": "RBSH"
+    },
+    {
+      "anchor": {
+        "x": 4.325,
+        "y": 0.5
+      },
+      "prevControl": {
+        "x": 2.825,
+        "y": 0.5000000000000002
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "RTSR"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 1.0,
+    "maxAcceleration": 3.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 1.0,
+    "rotation": 90.0
+  },
+  "reversed": false,
+  "folder": "RT",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 0.0
+  },
+  "useDefaultConstraints": false
+}

--- a/src/main/deploy/pathplanner/paths/RCME_RBSH.path
+++ b/src/main/deploy/pathplanner/paths/RCME_RBSH.path
@@ -1,0 +1,89 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 6.5,
+        "y": 3.3
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 6.5,
+        "y": 2.8
+      },
+      "isLocked": false,
+      "linkedName": "RCME"
+    },
+    {
+      "anchor": {
+        "x": 5.65,
+        "y": 2.5
+      },
+      "prevControl": {
+        "x": 6.15,
+        "y": 2.5
+      },
+      "nextControl": {
+        "x": 4.65,
+        "y": 2.5
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 2.75,
+        "y": 2.5
+      },
+      "prevControl": {
+        "x": 3.75,
+        "y": 2.5
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "RBSH"
+    }
+  ],
+  "rotationTargets": [
+    {
+      "waypointRelativePos": 1.0,
+      "rotationDegrees": 14.999999999999998
+    }
+  ],
+  "constraintZones": [
+    {
+      "name": "Bump",
+      "minWaypointRelativePos": 1.0,
+      "maxWaypointRelativePos": 1.75,
+      "constraints": {
+        "maxVelocity": 2.0,
+        "maxAcceleration": 3.0,
+        "maxAngularVelocity": 540.0,
+        "maxAngularAcceleration": 720.0,
+        "nominalVoltage": 12.0,
+        "unlimited": false
+      }
+    }
+  ],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 3.0,
+    "maxAcceleration": 3.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 0.0
+  },
+  "reversed": false,
+  "folder": "RT",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 90.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/RFME_RBSH.path
+++ b/src/main/deploy/pathplanner/paths/RFME_RBSH.path
@@ -1,0 +1,89 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 7.94,
+        "y": 3.3
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 7.94,
+        "y": 2.8
+      },
+      "isLocked": false,
+      "linkedName": "RFME"
+    },
+    {
+      "anchor": {
+        "x": 5.65,
+        "y": 2.5
+      },
+      "prevControl": {
+        "x": 6.65,
+        "y": 2.5
+      },
+      "nextControl": {
+        "x": 4.65,
+        "y": 2.5
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 2.75,
+        "y": 2.5
+      },
+      "prevControl": {
+        "x": 3.75,
+        "y": 2.5
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "RBSH"
+    }
+  ],
+  "rotationTargets": [
+    {
+      "waypointRelativePos": 1.0,
+      "rotationDegrees": 14.999999999999998
+    }
+  ],
+  "constraintZones": [
+    {
+      "name": "Bump",
+      "minWaypointRelativePos": 1.0,
+      "maxWaypointRelativePos": 1.75,
+      "constraints": {
+        "maxVelocity": 2.0,
+        "maxAcceleration": 3.0,
+        "maxAngularVelocity": 540.0,
+        "maxAngularAcceleration": 720.0,
+        "nominalVoltage": 12.0,
+        "unlimited": false
+      }
+    }
+  ],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 3.0,
+    "maxAcceleration": 3.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 0.0
+  },
+  "reversed": false,
+  "folder": "RT",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 90.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/RFME_RTS.path
+++ b/src/main/deploy/pathplanner/paths/RFME_RTS.path
@@ -32,16 +32,16 @@
     },
     {
       "anchor": {
-        "x": 4.45,
+        "x": 4.325,
         "y": 0.65
       },
       "prevControl": {
-        "x": 4.95,
+        "x": 4.825,
         "y": 0.6499999999999999
       },
       "nextControl": null,
       "isLocked": false,
-      "linkedName": "RTSB"
+      "linkedName": "RTS"
     }
   ],
   "rotationTargets": [

--- a/src/main/deploy/pathplanner/paths/RFME_RTSB.path
+++ b/src/main/deploy/pathplanner/paths/RFME_RTSB.path
@@ -67,7 +67,7 @@
   },
   "goalEndState": {
     "velocity": 3.0,
-    "rotation": 0.0
+    "rotation": 180.0
   },
   "reversed": false,
   "folder": "RT",

--- a/src/main/deploy/pathplanner/paths/RTSB_ROB.path
+++ b/src/main/deploy/pathplanner/paths/RTSB_ROB.path
@@ -62,7 +62,7 @@
   "folder": "RT",
   "idealStartingState": {
     "velocity": 3.0,
-    "rotation": 0.0
+    "rotation": 180.0
   },
   "useDefaultConstraints": true
 }

--- a/src/main/deploy/pathplanner/paths/RTSB_RTSHB.path
+++ b/src/main/deploy/pathplanner/paths/RTSB_RTSHB.path
@@ -62,7 +62,7 @@
   "folder": "RT",
   "idealStartingState": {
     "velocity": 3.0,
-    "rotation": 0.0
+    "rotation": 180.0
   },
   "useDefaultConstraints": true
 }

--- a/src/main/deploy/pathplanner/paths/RTSR_RCME.path
+++ b/src/main/deploy/pathplanner/paths/RTSR_RCME.path
@@ -1,0 +1,89 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 4.325,
+        "y": 0.5
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 5.325,
+        "y": 0.5
+      },
+      "isLocked": false,
+      "linkedName": "RTSR"
+    },
+    {
+      "anchor": {
+        "x": 5.5,
+        "y": 0.5
+      },
+      "prevControl": {
+        "x": 5.0,
+        "y": 0.5000000000000001
+      },
+      "nextControl": {
+        "x": 6.5,
+        "y": 0.5
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 6.5,
+        "y": 3.3
+      },
+      "prevControl": {
+        "x": 6.5,
+        "y": 2.3
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "RCME"
+    }
+  ],
+  "rotationTargets": [
+    {
+      "waypointRelativePos": 1.0,
+      "rotationDegrees": 90.0
+    }
+  ],
+  "constraintZones": [
+    {
+      "name": "Intake",
+      "minWaypointRelativePos": 1.5,
+      "maxWaypointRelativePos": 2.0,
+      "constraints": {
+        "maxVelocity": 1.5,
+        "maxAcceleration": 3.0,
+        "maxAngularVelocity": 540.0,
+        "maxAngularAcceleration": 720.0,
+        "nominalVoltage": 12.0,
+        "unlimited": false
+      }
+    }
+  ],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 3.0,
+    "maxAcceleration": 3.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 90.0
+  },
+  "reversed": false,
+  "folder": "RT",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 90.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/RTSR_RFME.path
+++ b/src/main/deploy/pathplanner/paths/RTSR_RFME.path
@@ -1,0 +1,93 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 4.325,
+        "y": 0.5
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 5.325,
+        "y": 0.5
+      },
+      "isLocked": false,
+      "linkedName": "RTSR"
+    },
+    {
+      "anchor": {
+        "x": 5.5,
+        "y": 0.5
+      },
+      "prevControl": {
+        "x": 5.0,
+        "y": 0.5000000000000001
+      },
+      "nextControl": {
+        "x": 6.5,
+        "y": 0.5
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 7.94,
+        "y": 3.3
+      },
+      "prevControl": {
+        "x": 7.94,
+        "y": 2.3
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "RFME"
+    }
+  ],
+  "rotationTargets": [
+    {
+      "waypointRelativePos": 1.0,
+      "rotationDegrees": 90.0
+    },
+    {
+      "waypointRelativePos": 1.5,
+      "rotationDegrees": 55.0
+    }
+  ],
+  "constraintZones": [
+    {
+      "name": "Intake",
+      "minWaypointRelativePos": 1.5,
+      "maxWaypointRelativePos": 2.0,
+      "constraints": {
+        "maxVelocity": 1.5,
+        "maxAcceleration": 3.0,
+        "maxAngularVelocity": 540.0,
+        "maxAngularAcceleration": 720.0,
+        "nominalVoltage": 12.0,
+        "unlimited": false
+      }
+    }
+  ],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 3.0,
+    "maxAcceleration": 3.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 90.0
+  },
+  "reversed": false,
+  "folder": "RT",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 90.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/java/org/teamtitanium/Robot.java
+++ b/src/main/java/org/teamtitanium/Robot.java
@@ -353,6 +353,7 @@ public class Robot extends LoggedRobot {
     autoChooser.addCmd("Right Outpost", autoRoutines::getRightOutpostAuto);
     autoChooser.addCmd("Left Double Pass", autoRoutines::leftDoublePass);
     autoChooser.addCmd("Right Double Pass", autoRoutines::rightDoublePass);
+    autoChooser.addCmd("Right Double Pass Bump", autoRoutines::rightDoublePassBump);
     autoChooser.addCmd("Straight Test", autoRoutines::straightTuningAuto);
 
     autoChooser.addCmd(

--- a/src/main/java/org/teamtitanium/autos/AutoRoutines.java
+++ b/src/main/java/org/teamtitanium/autos/AutoRoutines.java
@@ -390,14 +390,11 @@ public class AutoRoutines {
         Logger.recordOutput(
             "AutoRoutines/PathLoadError",
             "Failed to load PathPlanner path for auto '" + this.toString() + "': " + e);
-        // Pre-flip the fallback pose so that resetPose's AllianceFlipUtil.apply() results in the
-        // current pose (avoiding a double-flip on red alliance).
-        Pose2d fallbackPose =
-            AllianceFlipUtil.apply(RobotState.getInstance().getEstimatedPose());
+
+        Pose2d fallbackPose = AllianceFlipUtil.apply(RobotState.getInstance().getEstimatedPose());
         Translation2d fallbackTranslation = fallbackPose.getTranslation();
         return new PathPlannerPath(
-            List.of(
-                new Waypoint(fallbackTranslation, fallbackTranslation, fallbackTranslation)),
+            List.of(new Waypoint(fallbackTranslation, fallbackTranslation, fallbackTranslation)),
             PathConstraints.unlimitedConstraints(12.0),
             null,
             new GoalEndState(0.0, fallbackPose.getRotation()));

--- a/src/main/java/org/teamtitanium/autos/AutoRoutines.java
+++ b/src/main/java/org/teamtitanium/autos/AutoRoutines.java
@@ -8,7 +8,6 @@ import com.pathplanner.lib.path.PathConstraints;
 import com.pathplanner.lib.path.PathPlannerPath;
 import com.pathplanner.lib.path.Waypoint;
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -100,88 +99,31 @@ public class AutoRoutines {
     return routine.cmd();
   }
 
-  // public Command rightDHAuto() {
-  //   final AutoRoutine routine = factory.newRoutine("Right Double Pass Auto");
-  //   Path[] paths = new Path[] {Path.RTS_RFME, Path.RFME_RTSB, Path.RTSB_ROB, Path.ROB_RBB};
-  //   Command autoCmd = resetPose(paths[0]);
-
-  //   autoCmd =
-  //       autoCmd.andThen(
-  //           Commands.sequence(
-  //               followPath(Path.RTS_RFME, routine),
-  //               followPath(Path.RFME_RTSB, routine),
-  //               followPath(Path.RTSB_RTSHB, routine)));
-
-  //   autoCmd =
-  //       autoCmd.andThen(
-  //           Commands.parallel(
-  //                   setAutoScore(true),
-  //                   Commands.repeatingSequence(
-  //                       setAutoIntakeOverride(true),
-  //                       Commands.waitSeconds(1.0),
-  //                       setAutoIntakeOverride(false),
-  //                       Commands.waitSeconds(0.75)))
-  //               .withTimeout(5.0));
-
-  //   autoCmd =
-  //       autoCmd.andThen(
-  //           Commands.sequence(
-  //               followPath(Path.RTSHB_ROB, routine), followPath(Path.ROB_RBB, routine)));
-
-  //   autoCmd =
-  //       autoCmd.andThen(
-  //           Commands.parallel(
-  //               setAutoScore(true),
-  //               Commands.repeatingSequence(
-  //                   setAutoIntakeOverride(true),
-  //                   Commands.waitSeconds(1.0),
-  //                   setAutoIntakeOverride(false),
-  //                   Commands.waitSeconds(0.75))));
-  //   routine.active().onTrue(autoCmd);
-
-  //   return routine.cmd();
-  // }
-
   public Command rightDoublePassBump() {
     final AutoRoutine routine = factory.newRoutine("Right Double Pass Bump");
-    Command autoCmd = resetPose(Path.RTS_RFME);
+    Command autoCmd = resetPose(Path.RTSR_RFME);
 
     autoCmd =
         autoCmd.andThen(
             Commands.sequence(
-                followPath(Path.RTS_RFME, routine),
-                followPath(Path.RFME_RTS, routine),
-                followPath(Path.RTS_RB, routine)));
+                followPath(Path.RTSR_RFME, routine), followPath(Path.RFME_RBSH, routine)));
 
     autoCmd =
         autoCmd.andThen(
-            Commands.parallel(
-                    setAutoScore(true),
-                    Commands.repeatingSequence(
-                        setAutoIntakeOverride(true),
-                        Commands.waitSeconds(0.8),
-                        setAutoIntakeOverride(false),
-                        Commands.waitSeconds(0.75)))
-                .withTimeout(4.5));
+            Commands.deadline(
+                followPath(Path.RBSH_RTSR, routine),
+                Commands.waitSeconds(1.0).andThen(shuffleIntake())));
 
     autoCmd =
         autoCmd.andThen(
             Commands.sequence(
-                followPath(Path.RB_RTS, routine),
-                followPath(Path.RTS_RCME, routine),
-                followPath(Path.RCME_RTS, routine),
-                followPath(Path.RTS_RB, routine)));
+                followPath(Path.RTSR_RCME, routine), followPath(Path.RCME_RBSH, routine)));
 
     autoCmd =
         autoCmd.andThen(
-            Commands.parallel(
-                    setAutoScore(true),
-                    Commands.repeatingSequence(
-                        setAutoIntakeOverride(true),
-                        Commands.waitSeconds(0.75),
-                        setAutoIntakeOverride(false),
-                        Commands.waitSeconds(0.75)))
-                .withTimeout(4.5));
+            Commands.deadline(
+                followPath(Path.RBSH_RTSR, routine),
+                Commands.waitSeconds(1.0).andThen(shuffleIntake())));
 
     routine.active().onTrue(autoCmd);
 
@@ -266,15 +208,7 @@ public class AutoRoutines {
                 followPath(Path.LTS_LB, routine)));
 
     autoCmd =
-        autoCmd.andThen(
-            Commands.parallel(
-                    setAutoScore(true),
-                    Commands.repeatingSequence(
-                        setAutoIntakeOverride(true),
-                        Commands.waitSeconds(0.75),
-                        setAutoIntakeOverride(false),
-                        Commands.waitSeconds(0.75)))
-                .withTimeout(4.5));
+        autoCmd.andThen(Commands.parallel(setAutoScore(true), shuffleIntake()).withTimeout(4.5));
 
     routine.active().onTrue(autoCmd);
 
@@ -308,7 +242,6 @@ public class AutoRoutines {
         setAutoSpinUp(true),
         setAutoIntakeOverride(deployIntake),
         path.getPathCommand(),
-        // setAutoSpinUp(false),
         setAutoIntakeOverride(false));
   }
 
@@ -336,6 +269,18 @@ public class AutoRoutines {
                         path.getPathPlannerPath()
                             .getStartingHolonomicPose()
                             .orElse(Pose2d.kZero))));
+  }
+
+  private Command shuffleIntake() {
+    return shuffleIntake(0.75, 0.75);
+  }
+
+  private Command shuffleIntake(double outDelay, double inDelay) {
+    return Commands.repeatingSequence(
+        setAutoIntakeOverride(true),
+        Commands.waitSeconds(outDelay),
+        setAutoIntakeOverride(false),
+        Commands.waitSeconds(inDelay));
   }
 
   private Command setAutoIntake(boolean value) {
@@ -444,11 +389,13 @@ public class AutoRoutines {
         Logger.recordOutput(
             "AutoRoutines/PathLoadError",
             "Failed to load PathPlanner path for auto '" + this.toString() + "': " + e);
+        Translation2d currentTranslation =
+            RobotState.getInstance().getEstimatedPose().getTranslation();
         return new PathPlannerPath(
-            List.of(new Waypoint(new Translation2d(), new Translation2d(), new Translation2d())),
+            List.of(new Waypoint(currentTranslation, currentTranslation, currentTranslation)),
             PathConstraints.unlimitedConstraints(12.0),
             null,
-            new GoalEndState(0.0, Rotation2d.kZero));
+            new GoalEndState(0.0, RobotState.getInstance().getEstimatedPose().getRotation()));
       }
     }
   }

--- a/src/main/java/org/teamtitanium/autos/AutoRoutines.java
+++ b/src/main/java/org/teamtitanium/autos/AutoRoutines.java
@@ -390,13 +390,17 @@ public class AutoRoutines {
         Logger.recordOutput(
             "AutoRoutines/PathLoadError",
             "Failed to load PathPlanner path for auto '" + this.toString() + "': " + e);
-        Translation2d currentTranslation =
-            RobotState.getInstance().getEstimatedPose().getTranslation();
+        // Pre-flip the fallback pose so that resetPose's AllianceFlipUtil.apply() results in the
+        // current pose (avoiding a double-flip on red alliance).
+        Pose2d fallbackPose =
+            AllianceFlipUtil.apply(RobotState.getInstance().getEstimatedPose());
+        Translation2d fallbackTranslation = fallbackPose.getTranslation();
         return new PathPlannerPath(
-            List.of(new Waypoint(currentTranslation, currentTranslation, currentTranslation)),
+            List.of(
+                new Waypoint(fallbackTranslation, fallbackTranslation, fallbackTranslation)),
             PathConstraints.unlimitedConstraints(12.0),
             null,
-            new GoalEndState(0.0, RobotState.getInstance().getEstimatedPose().getRotation()));
+            new GoalEndState(0.0, fallbackPose.getRotation()));
       }
     }
   }

--- a/src/main/java/org/teamtitanium/autos/AutoRoutines.java
+++ b/src/main/java/org/teamtitanium/autos/AutoRoutines.java
@@ -277,10 +277,11 @@ public class AutoRoutines {
 
   private Command shuffleIntake(double outDelay, double inDelay) {
     return Commands.repeatingSequence(
-        setAutoIntakeOverride(true),
-        Commands.waitSeconds(outDelay),
-        setAutoIntakeOverride(false),
-        Commands.waitSeconds(inDelay));
+            setAutoIntakeOverride(true),
+            Commands.waitSeconds(outDelay),
+            setAutoIntakeOverride(false),
+            Commands.waitSeconds(inDelay))
+        .finallyDo(interrupted -> autoIntakeOverride = false);
   }
 
   private Command setAutoIntake(boolean value) {

--- a/src/main/java/org/teamtitanium/autos/AutoRoutines.java
+++ b/src/main/java/org/teamtitanium/autos/AutoRoutines.java
@@ -100,17 +100,58 @@ public class AutoRoutines {
     return routine.cmd();
   }
 
-  public Command rightDHAuto() {
-    final AutoRoutine routine = factory.newRoutine("Right Double Pass Auto");
-    Path[] paths = new Path[] {Path.RTS_RFME, Path.RFME_RTSB, Path.RTSB_ROB, Path.ROB_RBB};
-    Command autoCmd = resetPose(paths[0]);
+  // public Command rightDHAuto() {
+  //   final AutoRoutine routine = factory.newRoutine("Right Double Pass Auto");
+  //   Path[] paths = new Path[] {Path.RTS_RFME, Path.RFME_RTSB, Path.RTSB_ROB, Path.ROB_RBB};
+  //   Command autoCmd = resetPose(paths[0]);
+
+  //   autoCmd =
+  //       autoCmd.andThen(
+  //           Commands.sequence(
+  //               followPath(Path.RTS_RFME, routine),
+  //               followPath(Path.RFME_RTSB, routine),
+  //               followPath(Path.RTSB_RTSHB, routine)));
+
+  //   autoCmd =
+  //       autoCmd.andThen(
+  //           Commands.parallel(
+  //                   setAutoScore(true),
+  //                   Commands.repeatingSequence(
+  //                       setAutoIntakeOverride(true),
+  //                       Commands.waitSeconds(1.0),
+  //                       setAutoIntakeOverride(false),
+  //                       Commands.waitSeconds(0.75)))
+  //               .withTimeout(5.0));
+
+  //   autoCmd =
+  //       autoCmd.andThen(
+  //           Commands.sequence(
+  //               followPath(Path.RTSHB_ROB, routine), followPath(Path.ROB_RBB, routine)));
+
+  //   autoCmd =
+  //       autoCmd.andThen(
+  //           Commands.parallel(
+  //               setAutoScore(true),
+  //               Commands.repeatingSequence(
+  //                   setAutoIntakeOverride(true),
+  //                   Commands.waitSeconds(1.0),
+  //                   setAutoIntakeOverride(false),
+  //                   Commands.waitSeconds(0.75))));
+  //   routine.active().onTrue(autoCmd);
+
+  //   return routine.cmd();
+  // }
+
+  public Command rightDoublePassBump() {
+    final AutoRoutine routine = factory.newRoutine("Right Double Pass Bump");
+    Command autoCmd = resetPose(Path.RTS_RFME);
 
     autoCmd =
         autoCmd.andThen(
             Commands.sequence(
                 followPath(Path.RTS_RFME, routine),
-                followPath(Path.RFME_RTSB, routine),
-                followPath(Path.RTSB_RTSHB, routine)));
+                followPath(Path.RFME_RTS, routine),
+                followPath(Path.RTS_RB, routine)));
 
     autoCmd =
         autoCmd.andThen(
@@ -118,25 +159,30 @@ public class AutoRoutines {
                     setAutoScore(true),
                     Commands.repeatingSequence(
                         setAutoIntakeOverride(true),
-                        Commands.waitSeconds(1.0),
+                        Commands.waitSeconds(0.8),
                         setAutoIntakeOverride(false),
                         Commands.waitSeconds(0.75)))
-                .withTimeout(5.0));
+                .withTimeout(4.5));
 
     autoCmd =
         autoCmd.andThen(
             Commands.sequence(
-                followPath(Path.RTSHB_ROB, routine), followPath(Path.ROB_RBB, routine)));
+                followPath(Path.RB_RTS, routine),
+                followPath(Path.RTS_RCME, routine),
+                followPath(Path.RCME_RTS, routine),
+                followPath(Path.RTS_RB, routine)));
 
     autoCmd =
         autoCmd.andThen(
             Commands.parallel(
-                setAutoScore(true),
-                Commands.repeatingSequence(
-                    setAutoIntakeOverride(true),
-                    Commands.waitSeconds(1.0),
-                    setAutoIntakeOverride(false),
-                    Commands.waitSeconds(0.75))));
+                    setAutoScore(true),
+                    Commands.repeatingSequence(
+                        setAutoIntakeOverride(true),
+                        Commands.waitSeconds(0.75),
+                        setAutoIntakeOverride(false),
+                        Commands.waitSeconds(0.75)))
+                .withTimeout(4.5));
+
     routine.active().onTrue(autoCmd);
 
     return routine.cmd();
@@ -339,16 +385,21 @@ public class AutoRoutines {
    */
   public enum Path {
     RTS_RFME(PathAction.INTAKE),
-    RFME_RTS(PathAction.NOTHING, true),
-    RFME_RTSB(PathAction.NOTHING),
+    RTS_RCME(PathAction.INTAKE),
     RTS_RB(PathAction.SPIN_UP, true),
+    RTSR_RFME(PathAction.INTAKE),
+    RTSR_RCME(PathAction.INTAKE),
+    RFME_RTS(PathAction.NOTHING, true),
+    RFME_RBSH(PathAction.SPIN_UP, true),
+    RFME_RTSB(PathAction.NOTHING),
+    RCME_RBSH(PathAction.SPIN_UP, true),
     RTSB_RTSHB(PathAction.SPIN_UP, true),
     RTSB_ROB(PathAction.INTAKE),
     RTSHB_ROB(PathAction.INTAKE),
+    RCME_RTS(PathAction.NOTHING, true),
     ROB_RBB(PathAction.SPIN_UP, true),
     RB_RTS(PathAction.INTAKE),
-    RTS_RCME(PathAction.INTAKE),
-    RCME_RTS(PathAction.NOTHING, true),
+    RBSH_RTSR(PathAction.SCORE),
     LTS_LFME(PathAction.INTAKE),
     LFME_LTS(PathAction.NOTHING, true),
     LTS_LB(PathAction.SCORE, true),


### PR DESCRIPTION
- [x] Fix `getPathPlannerPath()` fallback: pre-flip the current pose with `AllianceFlipUtil.apply()` so that `resetPose()`'s subsequent `apply()` cancels it out, preventing an incorrect pose jump on red alliance

<!-- START COPILOT CODING AGENT TIPS -->
---

📱 Kick off Copilot coding agent tasks wherever you are with [GitHub Mobile](https://gh.io/cca-mobile-docs), available on iOS and Android.